### PR TITLE
Make istty_stdout definition static

### DIFF
--- a/src/colors.h
+++ b/src/colors.h
@@ -5,10 +5,10 @@
 #include <unistd.h>
 
 #define IFTTY_STDOUT(x) (istty_stdout ? (x) : "")
-uint8_t istty_stdout;
+static uint8_t istty_stdout;
 
 #define IFTTY_STDERR(x) (istty_stderr ? (x) : "")
-uint8_t istty_stderr;
+static uint8_t istty_stderr;
 
 #define C_RED_LIGHT    "1;31"
 #define C_GREEN_LIGHT  "1;32"


### PR DESCRIPTION
Without this, compilation fails with
```
/usr/local/bin/ld: /tmp//cc1rco4B.o:(.bss+0x2080220): multiple definition of `istty_stdout'; /tmp//ccIaYcw6.o:(.bss+0x0): first defined here
/usr/local/bin/ld: /tmp//cc1rco4B.o:(.bss+0x2080221): multiple definition of `istty_stderr'; /tmp//ccIaYcw6.o:(.bss+0x1): first defined here
```

..at least on FreeBSD and GCC 12. With this change, it compiles and runs as prescribed.